### PR TITLE
Add custom errors

### DIFF
--- a/lib/cli/chord.rb
+++ b/lib/cli/chord.rb
@@ -24,6 +24,8 @@ module Coltrane
             [Coltrane::Chord.new(notes: notes)]
           end
 
+        raise BadChordError unless @chords
+
         @chords.each do |chord|
           desc = "#{chord.name} chord:"
           Coltrane::Cli::Notes.new chord.notes, desc: desc

--- a/lib/cli/errors.rb
+++ b/lib/cli/errors.rb
@@ -34,6 +34,12 @@ module Coltrane
         super msg || 'Incorrect scale, please specify scale and root separated by `-`. Ex: `coltrane scale major-C'
       end
     end
+
+    class BadChordError < ColtraneCliError
+      def initialize(msg = nil)
+        super msg || 'Incorrect chord, please specify a set of chords separated by `-`. Ex: coltrane chord CM7'
+      end
+    end
   end
 end
 

--- a/lib/cli/errors.rb
+++ b/lib/cli/errors.rb
@@ -28,6 +28,12 @@ module Coltrane
               'is not available at the moment.'
       end
     end
+
+    class BadScaleError < ColtraneCliError
+      def initialize(msg = nil)
+        super msg || 'Incorrect scale, please specify scale and root separated by `-`. Ex: `coltrane scale major-C'
+      end
+    end
   end
 end
 

--- a/lib/cli/scale.rb
+++ b/lib/cli/scale.rb
@@ -5,6 +5,7 @@ module Coltrane
     # Interfaces commands with the scales functionality
     class Scale
       def self.parse(str)
+        raise BadScaleError unless str && str.include?('-')
         *scale_name, tone = str.split('-')
         Coltrane::Scale.fetch(scale_name.join('_'), tone)
       end


### PR DESCRIPTION
I've created custom errors for when the user forgets to specify the scale or chord (instead of giving a general 'method not valid' error, it should output a more human-friendly error)