### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Simply type `coltrane` or `coltrane shell` to enable interactive mode. You can t
 $ gem install coltrane
 ```
 
-PS: Once you install the gem the CLI is instaled in your system and it's ready to be used.
+PS: Once you install the gem the CLI is installed in your system and it's ready to be used.
 
 ## Any questions? Feature requests? Bugs?
 

--- a/lib/coltrane/theory/interval_sequence.rb
+++ b/lib/coltrane/theory/interval_sequence.rb
@@ -88,9 +88,9 @@ module Coltrane
         intervals[x]
       end
 
-      def shift(ammount)
+      def shift(amount)
         self.class.new(*intervals.map do |i|
-          (i.semitones + ammount) % 12
+          (i.semitones + amount) % 12
         end)
       end
 


### PR DESCRIPTION
Found via `codespell -L iterm,wisper,doesnt,arent`